### PR TITLE
Pass all `error` details in BEditaClientException

### DIFF
--- a/src/BEditaClient.php
+++ b/src/BEditaClient.php
@@ -571,19 +571,10 @@ class BEditaClient
         $this->response = $this->jsonApiClient->sendRequest(new Request($method, $uri, $headers, $body));
         if ($this->getStatusCode() >= 400) {
             // Something bad just happened.
-            $statusCode = $this->getStatusCode();
             $response = $this->getResponseBody();
-
-            $code = (string)$statusCode;
-            $reason = $this->getStatusMessage();
-            if (!empty($response['error']['code'])) {
-                $code = $response['error']['code'];
-            }
-            if (!empty($response['error']['title'])) {
-                $reason = $response['error']['title'];
-            }
-
-            throw new BEditaClientException(compact('code', 'reason'), $statusCode);
+            // Message will be 'error` array, if absent use status massage
+            $message = empty($response['error']) ? $this->getStatusMessage() : $response['error'];
+            throw new BEditaClientException($message, $this->getStatusCode());
         }
 
         return $this->response;

--- a/tests/TestCase/BEditaClientTest.php
+++ b/tests/TestCase/BEditaClientTest.php
@@ -1082,6 +1082,7 @@ class BEditaClientTest extends TestCase
         if ($expected instanceof \Exception) {
             static::expectException(get_class($expected));
             static::expectExceptionCode($expected->getCode());
+            static::expectExceptionMessage($expected->getMessage());
         }
         $method = $input['method'];
         $path = $input['path'];


### PR DESCRIPTION
Pass all `error` details, enable app clients to show them... 