### PR TITLE
feat: query string in path, on requestUri

### DIFF
--- a/src/BEditaClient.php
+++ b/src/BEditaClient.php
@@ -606,17 +606,6 @@ class BEditaClient
      */
     protected function requestUri(string $path, ?array $query = null) : Uri
     {
-        // if path contains query strings, remove them from path and add them to query filter
-        $url = parse_url($path);
-        if (!empty($url['query'])) {
-            $path = str_replace(sprintf('?%s', $url['query']), '', $path);
-            parse_str($url['query'], $queryFromPath);
-            if ($query == null) {
-                $query = [];
-            }
-            $query = array_merge($queryFromPath, $query);
-        }
-
         if (strpos($path, $this->apiBaseUrl) === 0) {
             // allow absolute URL if request on same API base url
             $uri = new Uri($path);
@@ -629,8 +618,11 @@ class BEditaClient
             $uri = $uri->withPath($uri->getPath() . $path);
         }
 
+        // if path contains query strings, remove them from path and add them to query filter
+        parse_str($uri->getQuery(), $uriQuery);
         if ($query) {
-            $uri = $uri->withQuery(http_build_query((array)$query));
+            $query = array_merge((array)$uriQuery, (array)$query);
+            $uri = $uri->withQuery(http_build_query($query));
         }
 
         return $uri;

--- a/src/BEditaClient.php
+++ b/src/BEditaClient.php
@@ -606,6 +606,17 @@ class BEditaClient
      */
     protected function requestUri(string $path, ?array $query = null) : Uri
     {
+        // if path contains query strings, remove them from path and add them to query filter
+        $url = parse_url($path);
+        if (!empty($url['query'])) {
+            $path = str_replace(sprintf('?%s', $url['query']), '', $path);
+            parse_str($url['query'], $queryFromPath);
+            if ($query == null) {
+                $query = [];
+            }
+            $query = array_merge($queryFromPath, $query);
+        }
+
         if (strpos($path, $this->apiBaseUrl) === 0) {
             // allow absolute URL if request on same API base url
             $uri = new Uri($path);

--- a/src/BEditaClient.php
+++ b/src/BEditaClient.php
@@ -606,17 +606,13 @@ class BEditaClient
      */
     protected function requestUri(string $path, ?array $query = null) : Uri
     {
-        if (strpos($path, $this->apiBaseUrl) === 0) {
-            // allow absolute URL if request on same API base url
-            $uri = new Uri($path);
-        } else {
-            $uri = new Uri($this->apiBaseUrl);
-            // add starting '/' if missing
+        if (strpos($path, $this->apiBaseUrl) !== 0) {
             if (substr($path, 0, 1) !== '/') {
                 $path = '/' . $path;
             }
-            $uri = $uri->withPath($uri->getPath() . $path);
+            $path = $this->apiBaseUrl . $path;
         }
+        $uri = new Uri($path);
 
         // if path contains query strings, remove them from path and add them to query filter
         parse_str($uri->getQuery(), $uriQuery);

--- a/tests/TestCase/BEditaClientTest.php
+++ b/tests/TestCase/BEditaClientTest.php
@@ -1014,7 +1014,7 @@ class BEditaClientTest extends TestCase
                     'fields' => ['links', 'meta'],
                 ],
             ],
-            'get users' => [
+            'get users query in path' => [
                 [
                     'method' => 'GET',
                     'path' => '/users?q=gustavosupporto',

--- a/tests/TestCase/BEditaClientTest.php
+++ b/tests/TestCase/BEditaClientTest.php
@@ -1000,20 +1000,20 @@ class BEditaClientTest extends TestCase
     public function sendRequestProvider()
     {
         return [
-            // 'get users' => [
-            //     [
-            //         'method' => 'GET',
-            //         'path' => '/users',
-            //         'query' => ['q' => 'gustavosupporto'],
-            //         'headers' => null,
-            //         'body' => null,
-            //     ],
-            //     [
-            //         'code' => 200,
-            //         'message' => 'OK',
-            //         'fields' => ['links', 'meta'],
-            //     ],
-            // ],
+            'get users' => [
+                [
+                    'method' => 'GET',
+                    'path' => '/users',
+                    'query' => ['q' => 'gustavosupporto'],
+                    'headers' => null,
+                    'body' => null,
+                ],
+                [
+                    'code' => 200,
+                    'message' => 'OK',
+                    'fields' => ['links', 'meta'],
+                ],
+            ],
             'get users query in path' => [
                 [
                     'method' => 'GET',

--- a/tests/TestCase/BEditaClientTest.php
+++ b/tests/TestCase/BEditaClientTest.php
@@ -1014,6 +1014,20 @@ class BEditaClientTest extends TestCase
                     'fields' => ['links', 'meta'],
                 ],
             ],
+            'get users' => [
+                [
+                    'method' => 'GET',
+                    'path' => '/users?q=gustavosupporto',
+                    'query' => null,
+                    'headers' => null,
+                    'body' => null,
+                ],
+                [
+                    'code' => 200,
+                    'message' => 'OK',
+                    'fields' => ['links', 'meta'],
+                ],
+            ],
             'post users bad query' => [
                 [
                     'method' => 'POST',

--- a/tests/TestCase/BEditaClientTest.php
+++ b/tests/TestCase/BEditaClientTest.php
@@ -1000,25 +1000,25 @@ class BEditaClientTest extends TestCase
     public function sendRequestProvider()
     {
         return [
-            'get users' => [
-                [
-                    'method' => 'GET',
-                    'path' => '/users',
-                    'query' => ['q' => 'gustavosupporto'],
-                    'headers' => null,
-                    'body' => null,
-                ],
-                [
-                    'code' => 200,
-                    'message' => 'OK',
-                    'fields' => ['links', 'meta'],
-                ],
-            ],
+            // 'get users' => [
+            //     [
+            //         'method' => 'GET',
+            //         'path' => '/users',
+            //         'query' => ['q' => 'gustavosupporto'],
+            //         'headers' => null,
+            //         'body' => null,
+            //     ],
+            //     [
+            //         'code' => 200,
+            //         'message' => 'OK',
+            //         'fields' => ['links', 'meta'],
+            //     ],
+            // ],
             'get users query in path' => [
                 [
                     'method' => 'GET',
-                    'path' => '/users?q=gustavosupporto',
-                    'query' => null,
+                    'path' => '/users?name=gustavo',
+                    'query' => ['surname' => 'supporto'],
                     'headers' => null,
                     'body' => null,
                 ],


### PR DESCRIPTION
This provides merge of query filter in calls like `apiClient->get('/my/path?with=query&string=some', ['some' => 'other'])`.