### PR TITLE
Log API request and response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.vagrant/*
 /composer.lock
 /tests/.env
+/tests/files/api.log
 /coverage/*
 /index.html
 /phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "require": {
         "php": ">=7.1",
         "php-http/guzzle6-adapter": "^1.1",
+        "monolog/monolog": "2.x-dev",
         "woohoolabs/yang": "^1.4"
     },
     "require-dev": {

--- a/src/BEditaClient.php
+++ b/src/BEditaClient.php
@@ -21,6 +21,7 @@ use WoohooLabs\Yang\JsonApi\Client\JsonApiClient;
  */
 class BEditaClient
 {
+    use LogTrait;
 
     /**
      * Last response.
@@ -611,7 +612,11 @@ class BEditaClient
         }
 
         // Send the request synchronously to retrieve the response.
-        $this->response = $this->jsonApiClient->sendRequest(new Request($method, $uri, $headers, $body));
+        // Request and response log performed only if configured via `initLogger()`
+        $request = new Request($method, $uri, $headers, $body);
+        $this->logRequest($request);
+        $this->response = $this->jsonApiClient->sendRequest($request);
+        $this->logResponse($this->response);
         if ($this->getStatusCode() >= 400) {
             // Something bad just happened.
             $response = $this->getResponseBody();

--- a/src/LogTrait.php
+++ b/src/LogTrait.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ */
+
+namespace BEdita\SDK;
+
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Basic SDK logging functions
+ */
+trait LogTrait
+{
+    /**
+     * internal Logger
+     *
+     * @var null|Logger
+     */
+    protected $logger = null;
+
+    /**
+     * Initialize and configure logger
+     *
+     * @param array $options Configuration options, 'log_file' key with log file path is mandatory
+     * @return bool True on successful initialization, false otherwise
+     */
+    public function initLogger(array $options): bool
+    {
+        // 'path' to log file is mandatory
+        if (empty($options['log_file'])) {
+            return false;
+        }
+
+        $this->logger = new Logger('be4-php-sdk');
+        $this->logger->pushHandler(new StreamHandler($options['log_file'], Logger::DEBUG));
+
+        return true;
+    }
+
+    /**
+     * Perform request log
+     *
+     * @param RequestInterface $request The request to log
+     * @return void
+     */
+    public function logRequest(RequestInterface $request) : void
+    {
+        if (!$this->logger) {
+            return;
+        }
+
+        $msg = sprintf(
+            'Request: %s %s - Headers %s - Body %s',
+            $request->getMethod(),
+            $request->getUri(),
+            $this->requestHeadersCleanup($request),
+            $this->requestBodyCleanup($request)
+        );
+        $this->logger->info($msg);
+    }
+
+    /**
+     * Return request body without sensitive information.
+     *
+     * @param RequestInterface $request The request to log
+     * @return string
+     */
+    protected function requestBodyCleanup(RequestInterface $request) : string
+    {
+        $body = $request->getBody();
+        if (empty((string)$body)) {
+            return '(empty)';
+        }
+
+        $data = json_decode($body, true);
+        foreach (['password', 'old_password', 'confirm-password'] as $p) {
+            if (!empty($data[$p])) {
+                $data[$p] = '***************';
+            }
+            if (!empty($data['data']['attributes'][$p])) {
+                $data['data']['attributes'][$p] = '***************';
+            }
+        }
+
+        return json_encode($data);
+    }
+
+    /**
+     * Return request headers as string without sensitive information.
+     *
+     * @param RequestInterface $request The request to log
+     * @return string
+     */
+    protected function requestHeadersCleanup(RequestInterface $request) : string
+    {
+        $headers = $request->getHeaders();
+        foreach (['Authorization', 'X-Api-Key'] as $h) {
+            if (!empty($headers[$h]) && !empty(array_diff($headers[$h], ['']))) {
+                $headers[$h] = ['***************'];
+            }
+        }
+
+        return json_encode($headers);
+    }
+
+    /**
+     * Perform response log
+     *
+     * @param ResponseInterface $response The response to log
+     * @return void
+     */
+    public function logResponse(ResponseInterface $response) : void
+    {
+        if (!$this->logger) {
+            return;
+        }
+
+        $msg = sprintf(
+            'Response: %s %s - Headers %s - Body %s',
+            $response->getStatusCode(),
+            $response->getReasonPhrase(),
+            json_encode($response->getHeaders()),
+            $this->responseBodyCleanup($response)
+        );
+        $this->logger->info($msg);
+    }
+
+    /**
+     * Return response body without sensitive information.
+     *
+     * @param ResponseInterface $response The response to log
+     * @return string
+     */
+    protected function responseBodyCleanup(ResponseInterface $response) : string
+    {
+        $body = $response->getBody();
+        if (empty((string)$body)) {
+            return '(empty)';
+        }
+
+        $data = json_decode($body, true);
+        foreach (['jwt', 'renew'] as $tok) {
+            if (!empty($data['meta'][$tok])) {
+                $data['meta'][$tok] = '***************';
+            }
+        }
+
+        return json_encode($data);
+    }
+}

--- a/tests/TestCase/LogTraitTest.php
+++ b/tests/TestCase/LogTraitTest.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * BEdita, API-first content management framework
+ * Copyright 2018 ChannelWeb Srl, Chialab Srl
+ *
+ * This file is part of BEdita: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See LICENSE.LGPL or <http://gnu.org/licenses/lgpl-3.0.html> for more details.
+ */
+namespace BEdita\SDK\Test\TestCase;
+
+use BEdita\SDK\BEditaClient;
+use BEdita\SDK\LogTrait;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * \BEdita\SDK\LogTrait Test Case
+ *
+ * @coversDefaultClass \BEdita\SDK\LogTrait
+ */
+class LogTraitTest extends TestCase
+{
+    /**
+     * SDK Client class
+     *
+     * @var \BEdita\SDK\BEditaClient
+     */
+    private $client = null;
+
+    /**
+     * Log file path
+     *
+     * @var string
+     */
+    private $logFile = null;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->client = new BEditaClient(getenv('BEDITA_API'), getenv('BEDITA_API_KEY'));
+        $response = $this->client->authenticate(getenv('BEDITA_ADMIN_USR'), getenv('BEDITA_ADMIN_PWD'));
+        $this->client->setupTokens($response['meta']);
+
+        // init empty log file
+        $this->logFile = getcwd() . '/tests/files/api.log';
+        file_put_contents($this->logFile, '');
+    }
+
+    /**
+     * Test `initLogger`
+     *
+     * @return void
+     *
+     * @covers ::initLogger()
+     */
+    public function testInitLogger()
+    {
+        $res = $this->client->initLogger(['log_file' => $this->logFile]);
+        static::assertTrue($res);
+    }
+
+    /**
+     * Test `initLogger` failure
+     *
+     * @return void
+     *
+     * @covers ::initLogger()
+     */
+    public function testInitLoggerFailure()
+    {
+        $res = $this->client->initLogger([]);
+        static::assertFalse($res);
+    }
+
+    /**
+     * Test `logRequest` & `logResponse`
+     *
+     * @return void
+     *
+     * @covers ::logRequest()
+     * @covers ::logResponse()
+     * @covers ::requestHeadersCleanup()
+     * @covers ::requestBodyCleanup()
+     */
+    public function testLogRequestResponse()
+    {
+        $res = $this->client->initLogger(['log_file' => $this->logFile]);
+        static::assertTrue($res);
+
+        $this->client->get('/home');
+        $lines = file($this->logFile);
+        static::assertNotEmpty($lines);
+        static::assertEquals(2, count($lines));
+        static::assertTrue(strpos($lines[0], '***************') !== false);
+        static::assertTrue(strpos($lines[0], 'Body (empty)') !== false);
+    }
+
+    /**
+     * Test empty logRequest` & `logResponse`
+     *
+     * @return void
+     *
+     * @covers ::logRequest()
+     * @covers ::logResponse()
+     */
+    public function testEmptyLogRequestResponse()
+    {
+        $this->client->get('/home');
+        $lines = file($this->logFile);
+        static::assertEmpty($lines);
+    }
+
+    /**
+     * Test `requestBodyCleanup` & `responseBodyCleanup()`
+     *
+     * @return void
+     *
+     * @covers ::requestBodyCleanup()
+     * @covers ::responseBodyCleanup()
+     */
+    public function testBodyCleanup()
+    {
+        $res = $this->client->initLogger(['log_file' => $this->logFile]);
+        static::assertTrue($res);
+
+        $response = $this->client->authenticate(getenv('BEDITA_ADMIN_USR'), getenv('BEDITA_ADMIN_PWD'));
+        $lines = file($this->logFile);
+        static::assertEquals(2, count($lines));
+        static::assertTrue(strpos($lines[0], '***************') !== false);
+        static::assertTrue(strpos($lines[1], '***************') !== false);
+    }
+
+    /**
+     * Test empty `responseBodyCleanup`
+     *
+     * @return void
+     *
+     * @covers ::responseBodyCleanup()
+     */
+    public function testEmptyResponseBodyCleanup()
+    {
+        $res = $this->client->initLogger(['log_file' => $this->logFile]);
+        static::assertTrue($res);
+
+        $data = ['type' => 'documents'];
+        $response = $this->client->post('/documents', json_encode(compact('data')));
+        $response = $this->client->deleteObject($response['data']['id'], 'documents');
+        $lines = file($this->logFile);
+        static::assertEquals(4, count($lines));
+        static::assertTrue(strpos($lines[3], 'Body (empty)') !== false);
+    }
+}


### PR DESCRIPTION
This PR introduces request and response logging via https://seldaek.github.io/monolog/

a new `LogTrait` class using `Monolog` was introduced

* request and response are logged only if `initLogger()` is properly called
* log only to file for now, with default formatting - custom handlers and formatters may be introduced later
* sensitive data like passwords or tokens are obfuscated
