### PR TITLE
feat: children utilities

### DIFF
--- a/src/BEditaClient.php
+++ b/src/BEditaClient.php
@@ -700,18 +700,20 @@ class BEditaClient
     public function getFolderChildren(string $uname, array $types = [], array $options = []): array
     {
         $endpoint = sprintf('/folders/%s/children', $uname);
-        $limit = $options['limit'] ?? null;
-        $sort = $options['order'] ?? null;
-        $relationships = $options['relationships'] ?? null;
         if (empty($types)) {
+            $filter = null;
+            $sort = $options['order'] ?? null;
+            $limit = $options['limit'] ?? null;
+            $relationships = $options['relationships'] ?? null;
+
             return $this->children($uname, $filter, $sort, $limit, $relationships);
         }
         $result = [];
         foreach ($types as $type) {
-            $limit = $options['limit'][$type] ?? null;
-            $sort = $options['order'][$type] ?? null;
-            $relationships = $options['relationships'][$type] ?? null;
             $filter = compact('type');
+            $sort = $options['order'][$type] ?? null;
+            $limit = $options['limit'][$type] ?? null;
+            $relationships = $options['relationships'][$type] ?? null;
             $result[$type] = $this->children($uname, $filter, $sort, $limit, $relationships);
         }
 


### PR DESCRIPTION
This provides 2 new methods:

1. getFolderChildren(string $uname, array $types = [], array $options = []): array

This extracts children of a folder by uname, filtering by types, applying options.

2. children(string $uname, array $filter = [], $sort = '-modified', int $limit = 20, array $relationships = []): array

This extracts children of a folder by uname by filter, sort, limit, embedding relationships data according to parameter $relationships.