### PR TITLE
Allow absolute url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,14 @@ env:
     - BEDITA_API=http://127.0.0.1:8080
     - BEDITA_ADMIN_USR=admin
     - BEDITA_ADMIN_PWD=admin
+    - BEDITA_DOCKER_IMG=bedita/bedita:4.1.0
 
 before_install:
   # Use GitHub OAuth token with Composer to increase API limits.
   - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi
-  - docker pull bedita/bedita:4-cactus
-  - docker run -d -p 127.0.0.1:8080:80 --env BEDITA_API_KEY=${BEDITA_API_KEY} --env BEDITA_ADMIN_USR=${BEDITA_ADMIN_USR} --env BEDITA_ADMIN_PWD=${BEDITA_ADMIN_PWD} bedita/bedita:4-cactus
+  - docker pull ${BEDITA_DOCKER_IMG}
+  - docker inspect ${BEDITA_DOCKER_IMG}
+  - docker run --name api -d -p 127.0.0.1:8080:80 --env BEDITA_API_KEY=${BEDITA_API_KEY} --env BEDITA_ADMIN_USR=${BEDITA_ADMIN_USR} --env BEDITA_ADMIN_PWD=${BEDITA_ADMIN_PWD} ${BEDITA_DOCKER_IMG}
   - sleep 10
   - docker ps -a
 
@@ -36,8 +38,9 @@ jobs:
   fast_finish: true
 
   include:
-    - php: 7.1
     - php: 7.2
+    - php: 7.3
+    - php: 7.4
     - php: 7.2
       env: "RUN=phpcs"
       before_install: skip

--- a/src/BEditaClient.php
+++ b/src/BEditaClient.php
@@ -633,7 +633,9 @@ class BEditaClient
     }
 
     /**
-     * Create request URI from path
+     * Create request URI from path.
+     * If path is absolute, i.e. it starts with scheme protocolo 'http' or 'https' path si used as it is.
+     * Otherwise `$this->apiBaseUrl` is prefixed.
      *
      * @param string $path Endpoint URL path (with or without starting `/`) or absolute API path
      * @param array|null $query Query string parameters.
@@ -641,7 +643,7 @@ class BEditaClient
      */
     protected function requestUri(string $path, ?array $query = null) : Uri
     {
-        if (strpos($path, $this->apiBaseUrl) !== 0) {
+        if (strpos($path, 'https://') !== 0 && strpos($path, 'http://') !== 0) {
             if (substr($path, 0, 1) !== '/') {
                 $path = '/' . $path;
             }

--- a/src/BEditaClient.php
+++ b/src/BEditaClient.php
@@ -634,8 +634,8 @@ class BEditaClient
 
     /**
      * Create request URI from path.
-     * If path is absolute, i.e. it starts with scheme protocolo 'http' or 'https' path si used as it is.
-     * Otherwise `$this->apiBaseUrl` is prefixed.
+     * If path is absolute, i.e. it starts with 'http://' or 'https://', path is unchanged.
+     * Otherwise `$this->apiBaseUrl` is prefixed, prepending a `/` if necessary.
      *
      * @param string $path Endpoint URL path (with or without starting `/`) or absolute API path
      * @param array|null $query Query string parameters.

--- a/tests/TestCase/BEditaClientTest.php
+++ b/tests/TestCase/BEditaClientTest.php
@@ -202,7 +202,7 @@ class BEditaClientTest extends TestCase
      */
     public function testAuthenticateFail()
     {
-        $expected = new BEditaClientException('[401] Login not successful');
+        $expected = new BEditaClientException('[401] Login request not successful');
         static::expectException(get_class($expected));
         static::expectExceptionMessage($expected->getMessage());
         $this->client->authenticate('baduser', 'badpassword');

--- a/tests/TestCase/BEditaClientTest.php
+++ b/tests/TestCase/BEditaClientTest.php
@@ -15,7 +15,6 @@ namespace BEdita\SDK\Test\TestCase;
 use BEdita\SDK\BEditaClient;
 use BEdita\SDK\BEditaClientException;
 use PHPUnit\Framework\TestCase;
-use Psr\Http\Message\ResponseInterface;
 
 /**
  * A simple class that extends BEditaClient.
@@ -1110,15 +1109,15 @@ class BEditaClientTest extends TestCase
                     'fields' => ['data', 'links', 'meta'],
                 ],
             ],
-            'absolute bad path' => [
+            'absolute path with 404' => [
                 [
                     'method' => 'GET',
-                    'path' => 'https://someURL',
+                    'path' => 'http://example.com/zzzzz',
                     'query' => null,
                     'headers' => null,
                     'body' => null,
                 ],
-                new BEditaClientException('[404] Not Found', 404),
+                new BEditaClientException('Not Found', 404),
             ],
         ];
     }


### PR DESCRIPTION
With this PR any absolute URL uing `http` or `https` is allowed, even if different from `$this->apiBaseUrl` 

This solves a problem where different URLs for the same API are allowed.

Bonus track:
* update .travis.yml
* fix new test error caused by a changed API response on login failure
