### PR TITLE
Use only one patch api call for relation replacements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     - BEDITA_API=http://127.0.0.1:8080
     - BEDITA_ADMIN_USR=admin
     - BEDITA_ADMIN_PWD=admin
-    - BEDITA_DOCKER_IMG=bedita/bedita:4.1.0
+    - BEDITA_DOCKER_IMG=bedita/bedita:4.2.0
 
 before_install:
   # Use GitHub OAuth token with Composer to increase API limits.

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     - BEDITA_API=http://127.0.0.1:8080
     - BEDITA_ADMIN_USR=admin
     - BEDITA_ADMIN_PWD=admin
-    - BEDITA_DOCKER_IMG=bedita/bedita:4.2.0
+    - BEDITA_DOCKER_IMG=bedita/bedita:4.2.1
 
 before_install:
   # Use GitHub OAuth token with Composer to increase API limits.

--- a/src/BEditaClient.php
+++ b/src/BEditaClient.php
@@ -307,33 +307,6 @@ class BEditaClient
     }
 
     /**
-     * Create an array of objects with just id and type and filter objects with meta data.
-     *
-     * @param array $data Related resources or objects to insert
-     * @return array Mapped and filtered items
-     */
-    private function mapItemsAndMeta(array $data): array
-    {
-        $items = $data;
-        $withMeta = null;
-        if (!empty($data[0])) {
-            $items = array_map(function ($item) {
-                return [
-                    'id' => $item['id'],
-                    'type' => $item['type'],
-                ];
-            }, $data);
-            $withMeta = array_filter($data, function ($item) {
-                return !empty($item['meta']);
-            });
-        } elseif (!empty($data['meta'])) {
-            $withMeta = $data;
-        }
-
-        return compact('items', 'withMeta');
-    }
-
-    /**
      * Replace a list of related resources or objects: previuosly related are removed and replaced with these.
      *
      * @param int|string $id Object id

--- a/src/BEditaClient.php
+++ b/src/BEditaClient.php
@@ -318,7 +318,7 @@ class BEditaClient
      */
     public function replaceRelated($id, string $type, string $relation, array $data, ?array $headers = null): ?array
     {
-        return $this->patch(sprintf('/%s/%s/relationships/%s', $type, $id, $relation), json_encode(['data' => $items]), $headers);
+        return $this->patch(sprintf('/%s/%s/relationships/%s', $type, $id, $relation), compact('data'), $headers);
     }
 
     /**

--- a/src/BEditaClient.php
+++ b/src/BEditaClient.php
@@ -345,19 +345,7 @@ class BEditaClient
      */
     public function replaceRelated($id, string $type, string $relation, array $data, ?array $headers = null): ?array
     {
-        $map = $this->mapItemsAndMeta($data);
-        $items = $map['items'];
-        $withMeta = $map['withMeta'];
-
-        $result = $this->patch(sprintf('/%s/%s/relationships/%s', $type, $id, $relation), json_encode(['data' => $items]), $headers);
-
-        if (!empty($withMeta)) {
-            $response = $this->response;
-            $this->post(sprintf('/%s/%s/relationships/%s', $type, $id, $relation), json_encode(['data' => $withMeta]), $headers);
-            $this->response = $response;
-        }
-
-        return $result;
+        return $this->patch(sprintf('/%s/%s/relationships/%s', $type, $id, $relation), json_encode(['data' => $items]), $headers);
     }
 
     /**

--- a/src/BEditaClient.php
+++ b/src/BEditaClient.php
@@ -318,7 +318,9 @@ class BEditaClient
      */
     public function replaceRelated($id, string $type, string $relation, array $data, ?array $headers = null): ?array
     {
-        return $this->patch(sprintf('/%s/%s/relationships/%s', $type, $id, $relation), compact('data'), $headers);
+        $body = compact('data');
+
+        return $this->patch(sprintf('/%s/%s/relationships/%s', $type, $id, $relation), json_encode($body), $headers);
     }
 
     /**

--- a/tests/TestCase/BEditaClientTest.php
+++ b/tests/TestCase/BEditaClientTest.php
@@ -1222,6 +1222,16 @@ class BEditaClientTest extends TestCase
                 ],
                 new BEditaClientException('[404] Not Found', 404),
             ],
+            'post users unauthorized' => [
+                [
+                    'method' => 'POST',
+                    'path' => '/users',
+                    'query' => null,
+                    'headers' => null,
+                    'body' => null,
+                ],
+                new BEditaClientException('Unauthorized', 401),
+            ],
         ];
     }
 

--- a/tests/TestCase/BEditaClientTest.php
+++ b/tests/TestCase/BEditaClientTest.php
@@ -37,14 +37,6 @@ class MyBEditaClient extends BEditaClient
     {
         return parent::sendRequest($method, $path, $query, $headers, $body);
     }
-
-    /**
-     * @inheritDoc
-     */
-    public function mapItemsAndMeta(array $data): array
-    {
-        return parent::mapItemsAndMeta($data);
-    }
 }
 
 /**
@@ -1321,48 +1313,6 @@ class BEditaClientTest extends TestCase
         static::assertEquals($expected['code'], $this->client->getStatusCode());
         static::assertEquals($expected['message'], $this->client->getStatusMessage());
         static::assertEmpty($response);
-    }
-
-    /**
-     * Data provider for `mapItemsAndMeta`
-     *
-     * @return array
-     */
-    public function mapItemsAndMetaProvider(): array
-    {
-        $items = [
-            0 => ['id' => 100, 'type' => 'ants'],
-            1 => ['id' => 101, 'type' => 'flyes'],
-            2 => ['id' => 102, 'type' => 'butterflyes'],
-        ];
-        $withMeta = ['id' => 103, 'type' => 'wolves', 'meta' => ['eyes' => 'blue']];
-
-        return [
-            'items no meta' => [
-                $items,
-                compact('items') + ['withMeta' => []],
-            ],
-            'map items with meta' => [
-                $withMeta,
-                ['items' => $withMeta] + compact('withMeta'),
-            ],
-        ];
-    }
-
-    /**
-     * Test `mapItemsAndMeta`.
-     *
-     * @param array $input
-     * @param array $expected
-     * @return void
-     *
-     * @covers ::mapItemsAndMeta()
-     * @dataProvider mapItemsAndMetaProvider()
-     */
-    public function testMapItemsAndMeta(array $input, array $expected): void
-    {
-        $actual = $this->invokeMethod($this->client, 'mapItemsAndMeta', [$input]);
-        static::assertEquals($expected, $actual);
     }
 
     /**


### PR DESCRIPTION
Now that https://github.com/bedita/bedita/pull/1727 has been merged, we can use a single PATCH call and restore the `replaceRelated` behaviour.