### PR TITLE
Allow custom config for GuzzleHTTP

### DIFF
--- a/src/BEditaClient.php
+++ b/src/BEditaClient.php
@@ -83,11 +83,12 @@ class BEditaClient
      *  - Auth tokens 'jwt' and 'renew' (optional)
      *
      * @param string $apiUrl API base URL
-     * @param string $apiKey API key
+     * @param string|null $apiKey API key
      * @param array $tokens JWT Autorization tokens as associative array ['jwt' => '###', 'renew' => '###']
+     * @param array $guzzleConfig Additional default configuration for GuzzleHTTP client.
      * @return void
      */
-    public function __construct(string $apiUrl, ?string $apiKey = null, array $tokens = [])
+    public function __construct(string $apiUrl, ?string $apiKey = null, array $tokens = [], array $guzzleConfig = [])
     {
         $this->apiBaseUrl = $apiUrl;
         $this->apiKey = $apiKey;
@@ -96,7 +97,7 @@ class BEditaClient
         $this->setupTokens($tokens);
 
         // setup an asynchronous JSON API client
-        $guzzleClient = Client::createWithConfig([]);
+        $guzzleClient = Client::createWithConfig($guzzleConfig);
         $this->jsonApiClient = new JsonApiClient($guzzleClient);
     }
 


### PR DESCRIPTION
This PR adds a constructor parameter that lets users pass a custom configuration for the underlying Guzzle client.

This is useful, for example, in a scenario where the APIs are exposed through a private network via HTTPS, but the API server uses a TLS certificate issued by a private CA: this way we can instruct Guzzle to use a custom CA bundle and consider the certificates issued by our private CA as valid.
Another useful scenario would be to let userland set a custom timeout for requests.