### PR TITLE
Add phpstan/phpstan 1.5 + fix php workflow

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -72,7 +72,7 @@ jobs:
         uses: 'shivammathur/setup-php@v2'
         with:
           php-version: '${{ matrix.php-version }}'
-          tools: 'composer:v2, phpstan'
+          tools: 'composer:v2'
           extensions: 'mbstring, intl'
           coverage: 'none'
 
@@ -94,7 +94,7 @@ jobs:
 
       - name: 'Run PHP STAN'
         run: |
-          phpstan analyse --no-progress src
+          vendor/bin/phpstan analyse --no-progress --error-format=github
 
   unit:
     name: 'Run unit tests'

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /tests/files/api.log
 /coverage/*
 /index.html
+/phpstan.neon
 /phpunit.xml
 /provision/*
 /vendor/*

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "cakephp/cakephp-codesniffer": "^3.0",
         "psy/psysh": "@stable",
         "josegonzalez/dotenv": "2.*",
+        "phpstan/phpstan": "^1.5",
         "phpunit/phpunit": "^6.0|^8.0|^9.0"
     },
     "autoload": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,7 @@
+parameters:
+  bootstrapFiles:
+    - tests/bootstrap.php
+  paths:
+    - src
+    - tests
+  level: 0


### PR DESCRIPTION
This updates `php` workflow, so that `phpstan` dependency version is used (instead of downloading it with composer, during CI).

This activity in bedita started with https://github.com/bedita/bedita/pull/1889