### PR TITLE
Delete and restore multiple objects by IDs

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -37,7 +37,7 @@ jobs:
     with:
       php_versions: '["7.4","8.1","8.2","8.3"]'
       bedita_version: '4'
-      coverage_min_percentage: 99
+      coverage_min_percentage: 96
 
   unit-5:
     uses: bedita/github-workflows/.github/workflows/php-unit.yml@v2

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -37,7 +37,7 @@ jobs:
     with:
       php_versions: '["7.4","8.1","8.2","8.3"]'
       bedita_version: '4'
-      coverage_min_percentage: 96
+      coverage_min_percentage: 99
 
   unit-5:
     uses: bedita/github-workflows/.github/workflows/php-unit.yml@v2

--- a/README.md
+++ b/README.md
@@ -221,6 +221,10 @@ You can trash an object with `delete(string $path, mixed $body = null, ?array $h
 
     // delete document by ID 99999 and type documents
     $response = $client->deleteObject(99999, 'documents'); // arguments passed are string|int $id, string $type
+
+    // delete multiple
+    $response = $client->deleteObjects([999991, 999992, 999993], 'documents');
+
 ```
 
 #### Restore data
@@ -230,6 +234,9 @@ Data in trashcan can be restored with `restoreObject(int|string $id, string $typ
 ```php
     // restore document 99999
     $response = $client->restoreObject(99999, 'documents'); // arguments passed are string|int $id, string $type
+
+    // restore multiple
+    $response = $client->restoreObjects([999991, 999992, 999993], 'documents');
 ```
 
 #### Hard delete
@@ -243,6 +250,9 @@ You can remove an object from trashcan with `remove(int|string $id)`.
 
     // permanently remove documents 99999
     $response = $client->remove(99999); // argument passed is string|int $id
+
+    // permanently remove multiple
+    $response = $client->removeObjects([999991, 999992, 999993]);
 ```
 
 ### Working with relations

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,9 @@
         ],
         "cs-check": "vendor/bin/phpcs --colors -p --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests",
         "cs-fix": "vendor/bin/phpcbf --colors --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests",
+        "stan": "vendor/bin/phpstan analyse",
         "test": "vendor/bin/phpunit --colors=always",
+        "coverage": "vendor/bin/phpunit --colors=always --coverage-html coverage",
         "update-dev": [
             "@composer update",
             "@cs-setup"

--- a/src/BEditaClient.php
+++ b/src/BEditaClient.php
@@ -383,14 +383,11 @@ class BEditaClient extends BaseClient
      */
     public function restoreObjects(array $ids, string $type = 'objects'): ?array
     {
-        return $this->patch(
-            '/trash',
-            json_encode([
-                'data' => [
-                    'id' => $ids,
-                    'type' => $type,
-                ],
-            ])
-        );
+        $res = null;
+        foreach ($ids as $id) {
+            $res = !empty($res) ? $res : $this->restoreObject($id, $type);
+        }
+
+        return $res;
     }
 }

--- a/src/BEditaClient.php
+++ b/src/BEditaClient.php
@@ -188,7 +188,6 @@ class BEditaClient extends BaseClient
      */
     public function deleteObjects(array $ids, string $type = 'objects'): ?array
     {
-        $response = null;
         try {
             $response = $this->delete(sprintf('/%s?ids=%s', $type, implode(',', $ids)));
         } catch (\Exception $e) {
@@ -220,7 +219,6 @@ class BEditaClient extends BaseClient
      */
     public function removeObjects(array $ids): ?array
     {
-        $response = null;
         try {
             $response = $this->delete(sprintf('/trash?ids=%s', implode(',', $ids)));
         } catch (\Exception $e) {

--- a/src/BEditaClient.php
+++ b/src/BEditaClient.php
@@ -188,7 +188,17 @@ class BEditaClient extends BaseClient
      */
     public function deleteObjects(array $ids, string $type = 'objects'): ?array
     {
-        return $this->delete(sprintf('/%s?ids=%s', $type, implode(',', $ids)));
+        $response = null;
+        try {
+            $response = $this->delete(sprintf('/%s?ids=%s', $type, implode(',', $ids)));
+        } catch (\Exception $e) {
+            // fallback to delete one by one, to be retrocompatible
+            foreach ($ids as $id) {
+                $response = !empty($response) ? $response : $this->deleteObject($id, $type);
+            }
+        }
+
+        return $response;
     }
 
     /**
@@ -210,7 +220,17 @@ class BEditaClient extends BaseClient
      */
     public function removeObjects(array $ids): ?array
     {
-        return $this->delete(sprintf('/trash?ids=%s', implode(',', $ids)));
+        $response = null;
+        try {
+            $response = $this->delete(sprintf('/trash?ids=%s', implode(',', $ids)));
+        } catch (\Exception $e) {
+            // fallback to delete one by one, to be retrocompatible
+            foreach ($ids as $id) {
+                $response = !empty($response) ? $response : $this->remove($id);
+            }
+        }
+
+        return $response;
     }
 
     /**

--- a/src/BEditaClient.php
+++ b/src/BEditaClient.php
@@ -180,6 +180,18 @@ class BEditaClient extends BaseClient
     }
 
     /**
+     * Delete objects (DELETE) => move to trashcan.
+     *
+     * @param array $ids Object ids
+     * @param string|null $type Object type name
+     * @return array|null Response in array format
+     */
+    public function deleteObjects(array $ids, string $type = 'objects'): ?array
+    {
+        return $this->delete(sprintf('/%s?ids=%s', $type, implode(',', $ids)));
+    }
+
+    /**
      * Remove an object => permanently remove object from trashcan.
      *
      * @param int|string $id Object id
@@ -188,6 +200,17 @@ class BEditaClient extends BaseClient
     public function remove($id): ?array
     {
         return $this->delete(sprintf('/trash/%s', $id));
+    }
+
+    /**
+     * Remove objects => permanently remove objects from trashcan.
+     *
+     * @param array $ids Object ids
+     * @return array|null Response in array format
+     */
+    public function removeObjects(array $ids): ?array
+    {
+        return $this->delete(sprintf('/trash?ids=%s', implode(',', $ids)));
     }
 
     /**
@@ -341,10 +364,30 @@ class BEditaClient extends BaseClient
     public function restoreObject($id, string $type): ?array
     {
         return $this->patch(
-            sprintf('/%s/%s', 'trash', $id),
+            sprintf('/trash/%s', $id),
             json_encode([
                 'data' => [
                     'id' => $id,
+                    'type' => $type,
+                ],
+            ])
+        );
+    }
+
+    /**
+     * Restore objects from trash
+     *
+     * @param array $ids Object ids
+     * @param string|null $type Object type
+     * @return array|null Response in array format
+     */
+    public function restoreObjects(array $ids, string $type = 'objects'): ?array
+    {
+        return $this->patch(
+            '/trash',
+            json_encode([
+                'data' => [
+                    'id' => $ids,
                     'type' => $type,
                 ],
             ])

--- a/tests/TestCase/BEditaClientTest.php
+++ b/tests/TestCase/BEditaClientTest.php
@@ -743,13 +743,13 @@ class BEditaClientTest extends TestCase
         static::assertEquals(204, $this->client->getStatusCode());
         static::assertEquals('No Content', $this->client->getStatusMessage());
         static::assertEmpty($response);
-        $response = $this->client->getObject($ids[0], $type);
+        $response = $this->client->getObjects($type, ['filter' => ['id' => $ids[0]]]);
         static::assertEmpty($response['data']);
         $response = $this->client->restoreObjects($ids, $type);
         static::assertEquals(204, $this->client->getStatusCode());
         static::assertEquals('No Content', $this->client->getStatusMessage());
         static::assertEmpty($response);
-        $response = $this->client->getObject($ids[0], $type);
+        $response = $this->client->getObjects($type, ['filter' => ['id' => $ids[0]]]);
         static::assertNotEmpty($response['data']);
         $response = $this->client->removeObjects($ids, $type);
         static::assertEquals(204, $this->client->getStatusCode());

--- a/tests/TestCase/BEditaClientTest.php
+++ b/tests/TestCase/BEditaClientTest.php
@@ -752,6 +752,10 @@ class BEditaClientTest extends TestCase
         static::assertEmpty($response);
         $response = $this->client->getObjects($type, ['filter' => ['id' => $ids[0]]]);
         static::assertNotEmpty($response['data']);
+        $response = $this->client->deleteObjects($ids, $type);
+        static::assertEquals(204, $this->client->getStatusCode());
+        static::assertEquals('No Content', $this->client->getStatusMessage());
+        static::assertEmpty($response);
         $response = $this->client->removeObjects($ids, $type);
         static::assertEquals(204, $this->client->getStatusCode());
         static::assertEquals('No Content', $this->client->getStatusMessage());
@@ -917,7 +921,7 @@ class BEditaClientTest extends TestCase
      * Test `removeObjects` on exception.
      *
      * @return void
-     * @covers removeObjects()
+     * @covers ::removeObjects()
      */
     public function testRemoveObjects(): void
     {
@@ -936,7 +940,7 @@ class BEditaClientTest extends TestCase
         $type = 'documents';
         $response = $client->save($type, ['title' => 'this is a test document']);
         $docId = $response['data']['id'];
-        $response = $client->deleteObject($docId, $type);
+        $client->deleteObject($docId, $type);
         $ids = [$docId, 'abc'];
         $actual = $client->removeObjects($ids, $type);
         static::assertEmpty($actual);

--- a/tests/TestCase/BEditaClientTest.php
+++ b/tests/TestCase/BEditaClientTest.php
@@ -15,7 +15,6 @@ namespace BEdita\SDK\Test\TestCase;
 
 use BEdita\SDK\BEditaClient;
 use BEdita\SDK\BEditaClientException;
-use Cake\Utility\Hash;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -1059,7 +1058,7 @@ class BEditaClientTest extends TestCase
     {
         $response = $this->client->save($input['type'], $input['data']);
 
-        return (int)Hash::get($response, 'data.id');
+        return (int)$response['data']['id'];
     }
 
     /**

--- a/tests/TestCase/BEditaClientTest.php
+++ b/tests/TestCase/BEditaClientTest.php
@@ -722,6 +722,7 @@ class BEditaClientTest extends TestCase
 
     /**
      * Test `deleteObjects`, `removeObjects` and `restoreObjects.
+     * Skip on be4 (delete multiple available from BEdita v5.28.0).
      *
      * @return void
      * @covers ::deleteObjects()
@@ -730,6 +731,15 @@ class BEditaClientTest extends TestCase
      */
     public function testDeleteRemoveRestore(): void
     {
+        $response = $this->client->get('/home');
+        $version = $response['meta']['version'];
+        $apiMajor = substr($version, 0, strpos($version, '.'));
+        if ($apiMajor === '4') {
+            // skip on be4
+            $this->markTestSkipped('Delete multiple available from BEdita v5.28.0');
+
+            return;
+        }
         $this->authenticate();
         $type = 'documents';
         $docId = $this->newObject([
@@ -802,12 +812,22 @@ class BEditaClientTest extends TestCase
 
     /**
      * Test `restoreObjects`.
+     * Skip on be4 (delete multiple available from BEdita v5.28.0).
      *
      * @return void
      * @covers ::restoreObjects()
      */
     public function testRestoreObjects(): void
     {
+        $response = $this->client->get('/home');
+        $version = $response['meta']['version'];
+        $apiMajor = substr($version, 0, strpos($version, '.'));
+        if ($apiMajor === '4') {
+            // skip on be4
+            $this->markTestSkipped('Delete multiple available from BEdita v5.28.0');
+
+            return;
+        }
         $this->authenticate();
         $type = 'documents';
         $docId = $this->newObject([

--- a/tests/TestCase/BaseClientTest.php
+++ b/tests/TestCase/BaseClientTest.php
@@ -604,10 +604,10 @@ class BaseClientTest extends TestCase
     }
 
     /**
-     * Test `refreshToken` on Invalid response from server.
+     * Test `refreshTokens` on Invalid response from server.
      *
      * @return void
-     * @covers ::refreshToken()
+     * @covers ::refreshTokens()
      */
     public function testRefreshTokenInvalidResponseFromServer(): void
     {


### PR DESCRIPTION
This introduces some utility functions to delete and restore multiple objects by IDs: `deleteObjects`, `removeObjects` and `restoreObjects`.
This introduces retrocompatible changes, although multiple objects delete is available by https://github.com/bedita/bedita/releases/tag/v5.28.0