### PR TITLE
Prepare release 4: BEdita API 5 only, php >= 8.1 and clone

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -32,16 +32,9 @@ jobs:
     with:
       php_versions: '["8.3"]'
 
-  unit-4:
-    uses: bedita/github-workflows/.github/workflows/php-unit.yml@v2
-    with:
-      php_versions: '["7.4","8.1","8.2","8.3"]'
-      bedita_version: '4'
-      coverage_min_percentage: 99
-
   unit-5:
     uses: bedita/github-workflows/.github/workflows/php-unit.yml@v2
     with:
-      php_versions: '["7.4","8.1","8.2","8.3"]'
+      php_versions: '["8.1","8.2","8.3"]'
       bedita_version: '5'
       coverage_min_percentage: 99

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ BEdita PHP Official PHP SDK
 
 ## Prerequisites
 
-* PHP 7.4, 8.0, 8.1, 8.2, 8.3
+* PHP >= 8.1
 * [Composer](https://getcomposer.org/doc/00-intro.md#installation-linux-unix-osx)
 
 ## Install

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.1",
         "monolog/monolog": "^2",
         "php-http/guzzle7-adapter": "^1.0",
         "woohoolabs/yang": "^3.0"
@@ -27,8 +27,8 @@
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^3.0",
         "josegonzalez/dotenv": "2.*",
-        "phpstan/phpstan": "^1.5",
-        "phpunit/phpunit": "^6.0|^8.0|^9.0",
+        "phpstan/phpstan": "^1.10",
+        "phpunit/phpunit": "^9.0",
         "psy/psysh": "@stable",
         "vimeo/psalm": "^5.18"
     },

--- a/src/BEditaClient.php
+++ b/src/BEditaClient.php
@@ -410,4 +410,30 @@ class BEditaClient extends BaseClient
 
         return $res;
     }
+
+    /**
+     * Clone an object.
+     * This requires BEdita API >= 5.36.0
+     *
+     * @param string $type Object type name
+     * @param string $id Source object id
+     * @param array $modified Object attributes to overwrite
+     * @param array $included Associations included: can be 'relationships' and 'translations'
+     * @param array|null $headers Custom request headers
+     * @return array|null Response in array format
+     */
+    public function clone(string $type, string $id, array $modified, array $included, ?array $headers = null): ?array
+    {
+        $body = json_encode([
+            'data' => [
+                'type' => $type,
+                'attributes' => $modified,
+                'meta' => [
+                    'included' => $included,
+                ],
+            ],
+        ]);
+
+        return $this->post(sprintf('/%s/%s/actions/clone', $type, $id), $body, $headers);
+    }
 }

--- a/tests/TestCase/BEditaClientTest.php
+++ b/tests/TestCase/BEditaClientTest.php
@@ -1179,6 +1179,7 @@ class BEditaClientTest extends TestCase
      * @covers ::thumbs()
      * @covers ::schema()
      * @covers ::relationData()
+     * @covers ::clone()
      */
     public function testMultipurpose(): void
     {
@@ -1439,5 +1440,16 @@ class BEditaClientTest extends TestCase
         static::assertArrayHasKey('data', $relationData);
         static::assertArrayHasKey('attributes', $relationData['data']);
         static::assertArrayHasKey('params', $relationData['data']['attributes']);
+
+        // test clone if BE version >= 5.36
+        $response = $this->client->get('/home');
+        $version = $response['meta']['version'];
+        $major = (int)explode('.', $version)[0];
+        $minor = (int)explode('.', $version)[1];
+        if ($major >= 5 && $minor >= 36) {
+            $clone = $this->client->clone('images', $mediaId, ['title' => 'Cloned image'], ['relationships', 'translations']);
+            static::assertNotEmpty($clone['data']['id']);
+            static::assertSame('Cloned image', $clone['data']['attributes']['title']);
+        }
     }
 }

--- a/tests/TestCase/BEditaClientTest.php
+++ b/tests/TestCase/BEditaClientTest.php
@@ -1441,15 +1441,9 @@ class BEditaClientTest extends TestCase
         static::assertArrayHasKey('attributes', $relationData['data']);
         static::assertArrayHasKey('params', $relationData['data']['attributes']);
 
-        // test clone if BE version >= 5.36
-        $response = $this->client->get('/home');
-        $version = $response['meta']['version'];
-        $major = (int)explode('.', $version)[0];
-        $minor = (int)explode('.', $version)[1];
-        if ($major >= 5 && $minor >= 36) {
-            $clone = $this->client->clone('images', $mediaId, ['title' => 'Cloned image'], ['relationships', 'translations']);
-            static::assertNotEmpty($clone['data']['id']);
-            static::assertSame('Cloned image', $clone['data']['attributes']['title']);
-        }
+        // test clone
+        $clone = $this->client->clone('images', $mediaId, ['title' => 'Cloned image'], ['relationships', 'translations']);
+        static::assertNotEmpty($clone['data']['id']);
+        static::assertSame('Cloned image', $clone['data']['attributes']['title']);
     }
 }


### PR DESCRIPTION
This introduces some breaking changes:

- php >= 8.1
- bedita >= 5

This also introduces `clone` function in `BEditaClient`.