### PR TITLE
Php 8.4

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -20,17 +20,17 @@ jobs:
   cs:
     uses: bedita/github-workflows/.github/workflows/php-cs.yml@v2
     with:
-      php_versions: '["8.3"]'
+      php_versions: '["8.4"]'
 
   psalm:
     uses: bedita/github-workflows/.github/workflows/php-psalm.yml@v2
     with:
-      php_versions: '["8.3"]'
+      php_versions: '["8.4"]'
 
   stan:
     uses: bedita/github-workflows/.github/workflows/php-stan.yml@v2
     with:
-      php_versions: '["8.3"]'
+      php_versions: '["8.4"]'
 
   unit-5:
     uses: bedita/github-workflows/.github/workflows/php-unit.yml@v2

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "phpstan/phpstan": "^1.12",
         "phpunit/phpunit": "^10.5.5 || ^11.1.3",
         "psy/psysh": "@stable",
-        "vimeo/psalm": "^5.18"
+        "vimeo/psalm": "^6.8"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This introduces php 8.4 in CI for phpcs, psalm and stan.
This is gonna be a patch, to include https://github.com/bedita/php-sdk/pull/57 to avoid deprecations on BEditaClientException. 