### PR TITLE
BEdita 6 for unit 6 tests

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -43,5 +43,5 @@ jobs:
     uses: bedita/github-workflows/.github/workflows/php-unit.yml@v2
     with:
       php_versions: '["8.4"]'
-      bedita_version: '6-alpha'
+      bedita_version: '6'
       coverage_min_percentage: 99


### PR DESCRIPTION
This updates github php tests workflow to use bedita version 6.